### PR TITLE
[UPGRADE] Adds version to docset name

### DIFF
--- a/godotdocset.py
+++ b/godotdocset.py
@@ -152,17 +152,18 @@ def get_version():
 
 class DocsetMaker:
 	outname = "Godot"
+	v_outname = outname+get_version()
 	# version_path = os.path.abspath(os.path.join("../", frompath, "./version.py"))
-	rootdir = outname + '.docset'
+	rootdir = outname + get_version() + '.docset'
 	docdir = rootdir + '/Contents/Resources/Documents'
 
 	def __enter__(self):
 		os.makedirs(self.docdir)
-		self.db = sqlite3.connect(DocsetMaker.outname + '.docset/Contents/Resources/docSet.dsidx')
+		self.db = sqlite3.connect(DocsetMaker.v_outname + '.docset/Contents/Resources/docSet.dsidx')
 		self.db.execute('CREATE TABLE searchIndex(id INTEGER PRIMARY KEY, name TEXT, type TEXT, path TEXT);')
 		self.db.execute('CREATE UNIQUE INDEX anchor ON searchIndex (name, type, path);')
-		with open(DocsetMaker.outname + '.docset/Contents/Info.plist', 'w') as plist:
-			plist.write(get_plist(DocsetMaker.outname, get_version()))
+		with open(DocsetMaker.v_outname + '.docset/Contents/Info.plist', 'w') as plist:
+			plist.write(get_plist(DocsetMaker.v_outname, get_version()))
 		self.db.execute("BEGIN")
 		return self
 

--- a/godotdocset.py
+++ b/godotdocset.py
@@ -151,7 +151,7 @@ def get_version():
 	return version
 
 class DocsetMaker:
-	outname = "Godot"+get_version()
+	outname = "Godot"
 	# version_path = os.path.abspath(os.path.join("../", frompath, "./version.py"))
 	rootdir = outname + '.docset'
 	docdir = rootdir + '/Contents/Resources/Documents'
@@ -198,7 +198,7 @@ def main():
 
 	if not os.path.exists(frompath) or not os.path.isdir(frompath):
 		exit("Directory " + frompath + " doesn't exist or is not a directory")
-	docsetdir = DocsetMaker.outname + ".docset"
+	docsetdir = DocsetMaker.outname + get_version() + ".docset"
 	if os.path.exists(docsetdir):
 		print("Removing docset dir")
 		shutil.rmtree(docsetdir)

--- a/godotdocset.py
+++ b/godotdocset.py
@@ -199,7 +199,7 @@ class DocsetMaker:
 def main():
 	if not os.path.exists(FROM_PATH) or not os.path.isdir(FROM_PATH):
 		exit("Directory " + FROM_PATH + " doesn't exist or is not a directory")
-	docsetdir = DocsetMaker.outname + VERSION + ".docset"
+	docsetdir = DocsetMaker.v_outname + ".docset"
 	if os.path.exists(docsetdir):
 		print("Removing docset dir")
 		shutil.rmtree(docsetdir)

--- a/godotdocset.py
+++ b/godotdocset.py
@@ -163,7 +163,7 @@ class DocsetMaker:
 		self.db.execute('CREATE TABLE searchIndex(id INTEGER PRIMARY KEY, name TEXT, type TEXT, path TEXT);')
 		self.db.execute('CREATE UNIQUE INDEX anchor ON searchIndex (name, type, path);')
 		with open(DocsetMaker.v_outname + '.docset/Contents/Info.plist', 'w') as plist:
-			plist.write(get_plist(DocsetMaker.v_outname, get_version()))
+			plist.write(get_plist(DocsetMaker.outname, get_version()))
 		self.db.execute("BEGIN")
 		return self
 

--- a/godotdocset.py
+++ b/godotdocset.py
@@ -114,7 +114,7 @@ class DocPage:
 			res.description = linkify_text(const)
 			self.consts[ename].append(res)
 
-def get_plist(name: str):
+def get_plist(name: str, version: str):
 	return '''<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -131,13 +131,28 @@ def get_plist(name: str):
 	<string>dashtoc</string>
 </dict>
 </plist>
-'''.format(name.split('_')[0],
-		name.replace('_', ' '),
-		name.split('_')[0].lower())
+'''.format(name.split('_')[0]+version, name.replace('_', ' ')+version, name.split('_')[0].lower())
 
+
+def get_args_from():
+	ap = argparse.ArgumentParser()
+	ap.add_argument('-f', '--from', help="folder or xml file", required=True)
+	# ap.add_argument('-t', '--to', help="output folder", default='.')
+	args = ap.parse_args()
+	frompath = args.__dict__['from']
+	return frompath
+
+def get_version():
+	VERSION_PATH = os.path.abspath(os.path.join(get_args_from(), "../../version.py"))
+	version = ""
+	for line in open(VERSION_PATH):
+		if line.startswith("docs ="):
+			version = "-"+line.split("=")[1].strip().strip('\"')
+	return version
 
 class DocsetMaker:
-	outname = "Godot"
+	outname = "Godot"+get_version()
+	# version_path = os.path.abspath(os.path.join("../", frompath, "./version.py"))
 	rootdir = outname + '.docset'
 	docdir = rootdir + '/Contents/Resources/Documents'
 
@@ -147,7 +162,7 @@ class DocsetMaker:
 		self.db.execute('CREATE TABLE searchIndex(id INTEGER PRIMARY KEY, name TEXT, type TEXT, path TEXT);')
 		self.db.execute('CREATE UNIQUE INDEX anchor ON searchIndex (name, type, path);')
 		with open(DocsetMaker.outname + '.docset/Contents/Info.plist', 'w') as plist:
-			plist.write(get_plist(DocsetMaker.outname))
+			plist.write(get_plist(DocsetMaker.outname, get_version()))
 		self.db.execute("BEGIN")
 		return self
 
@@ -179,11 +194,7 @@ class DocsetMaker:
 			add_entry(e.name, "Subroutine", "s_"+e.name)
 
 def main():
-	ap = argparse.ArgumentParser()
-	ap.add_argument('-f', '--from', help="folder or xml file", required=True)
-	# ap.add_argument('-t', '--to', help="output folder", default='.')
-	args = ap.parse_args()
-	frompath = args.__dict__['from']
+	frompath = get_args_from()
 
 	if not os.path.exists(frompath) or not os.path.isdir(frompath):
 		exit("Directory " + frompath + " doesn't exist or is not a directory")


### PR DESCRIPTION
Very basic "add version to docset" changes, allows to generate docsets for godot 3.x and 4.x using the `version.py` file on the godot source root folder and results in a declaration using the *Godot-X.x" syntax + folder of the same name

Changes, optimizations and error handling not implemented but would be very welcomed